### PR TITLE
fix(aws-iam): importedRoleStackSafeDefaultPolicyName feature flag results in excessively long IAM policy names

### DIFF
--- a/packages/aws-cdk-lib/aws-iam/lib/private/imported-role.ts
+++ b/packages/aws-cdk-lib/aws-iam/lib/private/imported-role.ts
@@ -1,4 +1,5 @@
 import { Construct } from 'constructs';
+import { MAX_POLICY_NAME_LEN } from './util';
 import { FeatureFlags, Names, Resource, Token, TokenComparison, Annotations } from '../../../core';
 import { IAM_IMPORTED_ROLE_STACK_SAFE_DEFAULT_POLICY_NAME } from '../../../cx-api';
 import { Grant } from '../grant';
@@ -45,9 +46,13 @@ export class ImportedRole extends Resource implements IRole, IComparablePrincipa
   public addToPrincipalPolicy(statement: PolicyStatement): AddToPrincipalPolicyResult {
     if (!this.defaultPolicy) {
       const useUniqueName = FeatureFlags.of(this).isEnabled(IAM_IMPORTED_ROLE_STACK_SAFE_DEFAULT_POLICY_NAME);
-      const defaultDefaultPolicyName = useUniqueName
-        ? `Policy${Names.uniqueId(this)}`
-        : 'Policy';
+      const prefix = 'Policy';
+      let defaultDefaultPolicyName = useUniqueName
+        ? `${prefix}${Names.uniqueId(this)}`
+        : prefix;
+      if (defaultDefaultPolicyName.length > MAX_POLICY_NAME_LEN) {
+        defaultDefaultPolicyName = `Policy${Names.uniqueResourceName(this, { maxLength: MAX_POLICY_NAME_LEN - prefix.length })}`;
+      }
       const policyName = this.defaultPolicyName ?? defaultDefaultPolicyName;
       this.defaultPolicy = new Policy(this, policyName, useUniqueName ? { policyName } : undefined);
       this.attachInlinePolicy(this.defaultPolicy);

--- a/packages/aws-cdk-lib/aws-iam/lib/private/util.ts
+++ b/packages/aws-cdk-lib/aws-iam/lib/private/util.ts
@@ -2,7 +2,7 @@ import { IConstruct } from 'constructs';
 import { captureStackTrace, DefaultTokenResolver, IPostProcessor, IResolvable, IResolveContext, Lazy, StringConcat, Token, Tokenization } from '../../../core';
 import { IPolicy } from '../policy';
 
-const MAX_POLICY_NAME_LEN = 128;
+export const MAX_POLICY_NAME_LEN = 128;
 
 export const LITERAL_STRING_KEY = 'LiteralString';
 

--- a/packages/aws-cdk-lib/aws-iam/test/role.from-role-arn.test.ts
+++ b/packages/aws-cdk-lib/aws-iam/test/role.from-role-arn.test.ts
@@ -78,6 +78,21 @@ describe('IAM Role.fromRoleArn', () => {
           expect(stack2PolicyNameCapture.asString()).toMatch(/PolicyRoleStack2ImportedRole.*/);
         });
 
+        test('Policy name is truncated to a maximum length of 128 characters when the original name exceeds this limit', () =>{
+          const appWithFeatureFlag = new App({ context: { [IAM_IMPORTED_ROLE_STACK_SAFE_DEFAULT_POLICY_NAME]: true } });
+          const roleStack1 = new Stack(appWithFeatureFlag, 'RoleStack1');
+
+          const tooLongString = 'x'.repeat(150);
+          const importedRoleInStack = Role.fromRoleArn(roleStack1, `ImportedRole${tooLongString}`,
+            `arn:aws:iam::${roleAccount}:role/${roleName}`);
+          importedRoleInStack.addToPrincipalPolicy(somePolicyStatement());
+
+          const stackPolicyNameCapture = new Capture();
+          Template.fromStack(roleStack1).hasResourceProperties('AWS::IAM::Policy', { PolicyName: stackPolicyNameCapture });
+
+          expect(stackPolicyNameCapture.asString()).toHaveLength(128);
+        });
+
         test('the same role imported in different stacks has the same default policy name without flag', () => {
           const appWithoutFeatureFlag = new App({ context: { [IAM_IMPORTED_ROLE_STACK_SAFE_DEFAULT_POLICY_NAME]: false } });
           const roleStack1 = new Stack(appWithoutFeatureFlag, 'RoleStack1');


### PR DESCRIPTION
When the importedRoleStackSafeDefaultPolicyName feature flag is enabled, the method to calculate the IAM Policy Name within aws_iam.ImportedRole.addToPrincipalPolicy() changes. Specifically, if the generated IAM Policy Name exceeds the maximum allowed length of 128 characters, it will be truncated using Names.uniqueResourceName().

Previously, the Names.UniqueId() method was used to generate the Policy Name. This method does not allow you to set a maximum length, so if the name exceeded the limit, it would be overwritten using Names.uniqueResourceName()—a function that allows for length specification.

I considered replacing Names.UniqueId() entirely with Names.uniqueResourceName(). However, this is on hold due to concerns that existing Policy Names could be affected. If a complete replacement poses no issues, your guidance is appreciated, as I'm not fully versed in the logic behind these methods.

Closes #<issue number here>.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
